### PR TITLE
This change introduces support for custom headers in HLS video stream…

### DIFF
--- a/components/VideoPlayer.tsx
+++ b/components/VideoPlayer.tsx
@@ -69,9 +69,22 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ streamUrl, onClose, channel, 
         let hls: any;
         const playVideo = () => video.play().catch(e => console.error("Autoplay was prevented:", e));
 
+        const hlsConfig: any = {
+            enableWorker: true,
+            lowLatencyMode: true
+        };
+
+        if (channel.headers) {
+            hlsConfig.xhrSetup = (xhr: XMLHttpRequest, url: string) => {
+                for (const key in channel.headers) {
+                    xhr.setRequestHeader(key, channel.headers[key]);
+                }
+            };
+        }
+
         if (streamUrl.endsWith('.m3u8')) {
             if (Hls.isSupported()) {
-                hls = new Hls({ enableWorker: true, lowLatencyMode: true });
+                hls = new Hls(hlsConfig);
                 hls.loadSource(streamUrl);
                 hls.attachMedia(video);
                 hls.on(Hls.Events.MANIFEST_PARSED, playVideo);
@@ -87,7 +100,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ streamUrl, onClose, channel, 
         return () => {
             if (hls) hls.destroy();
         };
-    }, [streamUrl]);
+    }, [streamUrl, channel.headers]);
 
     const showControls = useCallback(() => {
         setIsControlsVisible(true);

--- a/services/tvService.ts
+++ b/services/tvService.ts
@@ -195,6 +195,7 @@ export const fetchChannels = async (): Promise<Channel[]> => {
                             epg_id: channelData.epg_id,
                             network: channelData.network,
                             category: categorizeChannel(channelData),
+                            headers: channelData.headers,
                         };
                     }
                     return null;

--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,7 @@ export interface Channel {
   epg_id: string;
   network?: string;
   category: 'New Zealand' | 'International' | 'Religious' | 'Sports' | 'News';
+  headers?: { [key: string]: string };
 }
 
 export interface Programme {


### PR DESCRIPTION
…s, addressing an issue where some channels failed to load due to missing required HTTP headers.

The following changes were made:
- The `Channel` type in `types.ts` was updated to include an optional `headers` property.
- The `tvService.ts` was modified to extract these headers from the `tv.json` data source.
- The `VideoPlayer.tsx` component now dynamically adds these headers to HLS.js requests using `xhrSetup`.

This makes the video player more robust by allowing it to handle streams that require specific headers, such as `x-forwarded-for`, as specified in the data source. This should fix the playback for channels like Sky Open and Trackside Premier.