### PR TITLE
Fix broken streams for specific channels

### DIFF
--- a/components/VideoPlayer.tsx
+++ b/components/VideoPlayer.tsx
@@ -82,7 +82,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ streamUrl, onClose, channel, 
         
         let finalStreamUrl = streamUrl;
         if (channel.needsProxy) {
-            finalStreamUrl = `https://corsproxy.io/?${streamUrl}`;
+            finalStreamUrl = `https://thingproxy.freeboard.io/fetch/${streamUrl}`;
         }
 
         if (finalStreamUrl.endsWith('.m3u8')) {

--- a/services/tvService.ts
+++ b/services/tvService.ts
@@ -203,6 +203,9 @@ export const fetchChannels = async (): Promise<Channel[]> => {
                         // Fix for Sky Open: Use direct URL to avoid redirect issues with headers.
                         if (id === 'mjh-prime') {
                             channel.url = 'https://primetv-prod.akamaized.net/v1/prime-freeview-aes128.m3u8';
+                            // This channel's data includes an 'x-forwarded-for' header that causes CORS errors with the direct Akamai link.
+                            // By deleting the headers, we prevent the VideoPlayer component from adding them to the request.
+                            delete channel.headers;
                         }
 
                         // Fix for channels needing a CORS proxy


### PR DESCRIPTION
This commit addresses issues with two types of channel streams that were failing to load.

1.  **Sky Open (Prime) Stream:** This stream was failing due to a CORS policy error. The application was sending an `x-forwarded-for` header, which is not allowed by the Akamai server hosting the stream. The fix involves removing the custom headers for this specific channel in `services/tvService.ts` to prevent the forbidden header from being added to the request.

2.  **Proxied Streams (e.g., Whakaata Māori, Te Reo):** These streams were failing because `hls.js` could not correctly resolve relative paths in the `.m3u8` playlist when using the `corsproxy.io` proxy. The fix involves switching to a different proxy (`thingproxy.freeboard.io`) in `components/VideoPlayer.tsx`. This proxy uses a URL structure that is more compatible with how `hls.js` handles playlist URLs, ensuring that relative paths are resolved correctly.

These changes are targeted and should not affect other channels that are currently working.