### PR TITLE
Update README and change app name to Kiwi TV

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,7 +13,7 @@ const AppHeader: React.FC<{
     scheduleButtonRef: React.RefObject<HTMLButtonElement>;
 }> = ({ onOpenSchedule, currentShowTitle, scheduleButtonRef }) => (
     <header className="fixed top-0 left-0 right-0 z-20 h-20 flex items-center justify-between px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-black/50 to-transparent pointer-events-none">
-        <h1 className="text-2xl font-bold text-white drop-shadow-lg pointer-events-auto">Free<span className="text-primary-red-ochre">TV</span></h1>
+        <h1 className="text-2xl font-bold text-white drop-shadow-lg pointer-events-auto">Kiwi<span className="text-primary-red-ochre">TV</span></h1>
 
         <div className="flex items-center gap-4 pointer-events-auto">
             <button

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Kiwi TV
 
-This is a web application for watching TV channels.
+Welcome to Kiwi TV! This is a sleek and modern web application designed for watching New Zealand TV channels live. It provides a user-friendly interface to browse channels and see what's currently on air.
+
+## Features
+
+*   **Live TV Streaming:** Watch your favorite New Zealand channels directly in your browser.
+*   **Interactive TV Guide:** See the current schedule for each channel.
+*   **Modern Interface:** A clean and responsive design that looks great on any device.
+
+## Data Source
+
+This application is powered by the incredible work of [Matt Huisman](https://www.matthuisman.nz/). The channel and Electronic Program Guide (EPG) data is sourced from his public IPTV resources at [i.mjh.nz](https://i.mjh.nz/). A huge thank you to Matt for making this data available!
 
 ## Run Locally
 


### PR DESCRIPTION
- The README has been updated to be more descriptive and to give credit to the data source.
- The app name displayed in the header has been changed from 'FreeTV' to 'Kiwi TV'.