### PR TITLE
Fix: Center video subtitles

### DIFF
--- a/components/VideoPlayer.tsx
+++ b/components/VideoPlayer.tsx
@@ -76,6 +76,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ streamUrl, onClose, channel, 
             text-align: center;
             font-size: 1.5rem;
             line-height: 1.4;
+            width: 100%;
         }
         `;
         document.head.appendChild(style);


### PR DESCRIPTION
The subtitles were previously aligned to the left of the video screen. This was because the `::cue` element did not have a specified width, causing it to default to the width of the text content and align to the start of the video frame.

This change sets the width of the `video::cue` pseudo-element to 100%. This makes the cue box span the full width of the video player. With `text-align: center` already in place, the subtitle text is now correctly centered within the video frame.